### PR TITLE
fix panic error when extracting boundary without surrounding quotes

### DIFF
--- a/message.go
+++ b/message.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"log"
+	"mime"
 	"strings"
 	"time"
 )
@@ -207,30 +208,9 @@ func ContentFromString(data string) *Content {
 // extractBoundary extract boundary string in contentType.
 // It returns empty string if no valid boundary found
 func extractBoundary(contentType string) string {
-	var boundary string
-	// first searching for the 'boundary=' token
-	boundaryIdx := strings.Index(contentType, "boundary=")
-	if boundaryIdx > -1 && len(contentType) > boundaryIdx+9 {
-		// then id check if what is the next char after '='
-		firstCharIdx := boundaryIdx + 9
-		if contentType[firstCharIdx] == '"' {
-			// ok, searching for the close quote
-			closeQuoteIdx := strings.Index(contentType[firstCharIdx+1:], "\"")
-			if closeQuoteIdx > -1 {
-				boundary = contentType[firstCharIdx+1 : firstCharIdx+closeQuoteIdx+1]
-			}
-		} else {
-			// that mean the boundary not quoted, check for ';' or 'space'
-			// or any kind of newline
-			terminateIdx := strings.IndexAny(contentType[firstCharIdx:], "; \r\n")
-			if terminateIdx > -1 {
-				boundary = contentType[firstCharIdx : firstCharIdx+terminateIdx]
-			} else {
-				// the boundary is the last param of contentType
-				boundary = contentType[firstCharIdx:]
-			}
-		}
+	_, params, err := mime.ParseMediaType(contentType)
+	if err == nil {
+		return params["boundary"]
 	}
-
-	return boundary
+	return ""
 }

--- a/message.go
+++ b/message.go
@@ -119,6 +119,9 @@ func (content *Content) ParseMIMEBody() *MIMEBody {
 			var p []string
 			if len(boundary) > 0 {
 				p = strings.Split(content.Body, "--"+boundary)
+				log.Printf("Got boundary: %s", boundary)
+			} else {
+				log.Printf("Boundary not found: %s", hdr[0])
 			}
 
 			for _, s := range p {

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,27 @@
+package data
+
+import (
+	"testing"
+)
+
+func TestExtractBoundary(t *testing.T) {
+	contents := []struct {
+		content string
+		expect  string
+	}{
+		{
+			`multipart/alternative; boundary="_----------=_MCPart_498914860"`,
+			`_----------=_MCPart_498914860`,
+		},
+		{
+			`multipart/alternative; boundary=047d7bd74a2049b624050d805118`,
+			`047d7bd74a2049b624050d805118`,
+		},
+	}
+
+	for _, c := range contents {
+		if b := extractBoundary(c.content); b != c.expect {
+			t.Fatal("extractBoundary expect", c.expect, "but get", b)
+		}
+	}
+}


### PR DESCRIPTION
I have reported an issue here https://github.com/mailhog/MailHog/issues/33
The current implement will lead to panic if the boundary come without surrounding quotes.
