### PR TITLE
Ignore the first and last "parts" in multipart messages

### DIFF
--- a/message.go
+++ b/message.go
@@ -192,6 +192,7 @@ func (content *Content) ParseMIMEBody() *MIMEBody {
 			var p []string
 			if len(boundary) > 0 {
 				p = strings.Split(content.Body, "--"+boundary)
+				p = p[1 : len(p)-1]
 				logf("Got boundary: %s", boundary)
 			} else {
 				logf("Boundary not found: %s", hdr[0])


### PR DESCRIPTION
In my experience, MailHog's MIME tab displays every email as having an empty initial part and a 2-byte final part (consisting of 2 dashes). This is because MailHog is incorrectly treating content before the initial boundary and after the final boundary as real parts. This content should be ignored, as specified by RFC 2046:
> There appears to be room for additional information prior to the
> first boundary delimiter line and following the final boundary
> delimiter line.  These areas should generally be left blank, and
> implementations must ignore anything that appears before the first
> boundary delimiter line or after the last one.

This PR will make MailHog ignore everything before the first multipart boundary and after the last one.