### PR TITLE
Test & fix headers folded across multiple lines

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -1,8 +1,35 @@
 package data
 
 import (
+	"reflect"
 	"testing"
 )
+
+func TestContentFromString(t *testing.T) {
+	// Long headers can be folded across multiple lines.
+	get := ContentFromString(
+		"To: foo@bar.com\r\n" +
+			"X-Foo-Digest:\r\n" +
+			" f71324948a11ad59c9f52aa27a1f194391968da6b7623186fedd0d190fd2f484\r\n" +
+			"\r\n" +
+			"body\r\n",
+	)
+
+	expect := &Content{
+		Body: "body\r\n",
+		Headers: map[string][]string{
+			"To": []string{"foo@bar.com"},
+			"X-Foo-Digest": []string{
+				"f71324948a11ad59c9f52aa27a1f194391968da6b7623186fedd0d190fd2f484",
+			},
+		},
+		Size: 107,
+	}
+
+	if !reflect.DeepEqual(get, expect) {
+		t.Fatal("ContentFromString expect", expect, "but get", get)
+	}
+}
 
 func TestExtractBoundary(t *testing.T) {
 	contents := []struct {


### PR DESCRIPTION
Didn't change the API, which meant I have no way to return errors, not sure if all callers will handle a nil coming back.

But this fixes a real issue we found at $WORK.