### PR TITLE
Add support for BCC

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -25,3 +25,76 @@ func TestExtractBoundary(t *testing.T) {
 		}
 	}
 }
+
+func TestPathEquals(t *testing.T) {
+	a := Path{
+		Relays:  []string{"rel"},
+		Mailbox: "foo",
+		Domain:  "bar",
+		Params:  "",
+	}
+
+	if a.equals(nil) {
+		t.Errorf("Path should never be equal to nil")
+	}
+
+	if !a.equals(&a) {
+		t.Errorf("references should be equal")
+	}
+	b := a
+	if !a.equals(&b) {
+		t.Errorf("%s should be equal to %s.", a, b)
+	}
+	mailboxChanged := a
+	mailboxChanged.Mailbox = "!"
+	if a.equals(&mailboxChanged) {
+		t.Errorf("%s should NOT be equal to %s.", a, mailboxChanged)
+	}
+	domainChanged := a
+	domainChanged.Domain = "!"
+	if a.equals(&domainChanged) {
+		t.Errorf("%s should NOT be equal to %s.", a, domainChanged)
+	}
+	paramsChanged := a
+	paramsChanged.Params = "!"
+	if a.equals(&paramsChanged) {
+		t.Errorf("%s should NOT be equal to %s.", a, paramsChanged)
+	}
+	relaysChanged := a
+	relaysChanged.Relays = []string{"baz"}
+	if a.equals(&relaysChanged) {
+		t.Errorf("%s should NOT be equal to %s.", a, relaysChanged)
+	}
+	relaysChanged.Relays = []string{"baz", "rel"}
+	if a.equals(&relaysChanged) {
+		t.Errorf("%s should NOT be equal to %s.", a, relaysChanged)
+	}
+}
+
+func TestExtractBcc(t *testing.T) {
+	content := Content{
+		Size:    42,
+		Headers: map[string][]string{},
+		Body:    "body",
+	}
+	emptyTo := extractBcc(toPathes([]string{}), &content)
+	if l := len(emptyTo); l != 0 {
+		t.Errorf("result should be empty but had %d entries.", l)
+	}
+
+	content.Headers["Cc"] = []string{"admin@localhost, Alice <cjoao0@tinyurl.com>, aalesipo@example.com"}
+	content.Headers["To"] = []string{"circulars@localhost, Bob <mdenslow2@taobao.com>"}
+	allTos := []string{
+		"circulars@localhost", "admin@localhost", "cjoao0@tinyurl.com",
+		"aalesipo@example.com", "admin@localhost", "mdenslow2@taobao.com"}
+	bcc := extractBcc(toPathes(allTos), &content)
+	if l := len(bcc); l != 2 {
+		t.Errorf("%v should have 2 entries but had %d entries.", bcc, l)
+	}
+	for _, x := range []string{"admin@localhost", "mdenslow2@taobao.com"} {
+		if indexOf(bcc, PathFromString(x)) == -1 {
+			t.Errorf("%v should contain %s.", bcc, x)
+		}
+	}
+
+}


### PR DESCRIPTION
As mailhog is primarily a debugging tool we want to validate the correctness of bcc and cc as well.

See [#98](https://github.com/mailhog/MailHog/issues/98), [#261](https://github.com/mailhog/MailHog/issues/261)

## Possible solutions
- multiply the emails for each recipient
- show cc and bcc addresses in the preview

Duplicating emails won't help debugging and may make it even worse. So we went for the "show in preview" option. 


## Implementation

Bcc should not be contained in the mail source. Otherwise it wouldn't be a "blind" copy as the recipients could see the blind copy recipients. Every recipient (to, cc, bcc) should be part of the `RCPT` though. So from my understanding and the insight of this [Mailtrap article](https://mailtrap.io/blog/cc-bcc-in-smtp/) bcc should be `allRecipients - to - cc`. This calculated bcc is what I implemented and added to the `Message` struct.

On the GUI side I decided to follow the [suggestion of 
jankonas](https://github.com/mailhog/MailHog/issues/98#issuecomment-262234546) and show cc and bcc alongside with "from" and "subject". Cc and bcc are only shown if they have content. This way the user can easily debug who should've received the mail.